### PR TITLE
feat: SelectBoxコンポーネント作成

### DIFF
--- a/components/molecules/SelectBox/SelectBox.module.sass
+++ b/components/molecules/SelectBox/SelectBox.module.sass
@@ -1,14 +1,11 @@
-@use 'styles/index.sass' as *
+@use "/styles/index.sass" as *
 
-.input
+.selectBox
   +br6()
   +fs12()
   outline: 1px solid $gray
   padding: 6px 8px
   width: 100%
-
-  &:focus
-    outline-width: 2px
 
   +viewS()
     padding: 4px 6px

--- a/components/molecules/SelectBox/SelectBox.stories.ts
+++ b/components/molecules/SelectBox/SelectBox.stories.ts
@@ -1,0 +1,39 @@
+import { StoryObj } from "@storybook/react";
+import SelectBox from "./SelectBox";
+
+export default {
+  component: SelectBox,
+};
+
+type Story = StoryObj<typeof SelectBox>;
+
+export const ValueTypeString: Story = {
+  args: {
+    options: [
+      { label: "String 1", value: "1" },
+      { label: "String 2", value: "2" },
+      { label: "String 3", value: "3" },
+    ],
+  },
+};
+
+export const ValueTypeNumber: Story = {
+  args: {
+    options: [
+      { label: "Number 1", value: 1 },
+      { label: "Number 2", value: 2 },
+      { label: "Number 3", value: 3 },
+    ],
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    options: [
+      { label: "Disabled 1", value: 1 },
+      { label: "Disabled 2", value: 2 },
+      { label: "Disabled 3", value: 3 },
+    ],
+    disabled: true,
+  },
+};

--- a/components/molecules/SelectBox/SelectBox.tsx
+++ b/components/molecules/SelectBox/SelectBox.tsx
@@ -1,0 +1,48 @@
+import clsx from "clsx";
+import s from "./SelectBox.module.sass";
+
+type Option = {
+  label: string;
+  value: string | number;
+};
+
+interface Props {
+  className?: string;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  options: Option[];
+}
+
+const SelectBox: React.FC<Props> = ({
+  className,
+  id,
+  name,
+  disabled,
+  options,
+}) => {
+  const selectBoxClassNames = clsx(s.selectBox, className, {
+    [s.disabled]: disabled === true,
+  });
+
+  return (
+    <select
+      id={id}
+      name={name}
+      className={selectBoxClassNames}
+      disabled={disabled}
+      autoFocus={false}
+    >
+      {options.map((option) => (
+        <option
+          key={option.value}
+          value={option.value}
+        >
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+};
+
+export default SelectBox;

--- a/components/molecules/TextBox/TextBox.tsx
+++ b/components/molecules/TextBox/TextBox.tsx
@@ -18,13 +18,16 @@ const TextBox: React.FC<Props> = ({
   disabled = false,
   className,
 }) => {
+  const inputClassNames = clsx(s.input, className, {
+    [s.disabled]: disabled === true,
+  });
   return (
     <input
       type={type}
       name={name}
       placeholder={placeholder}
       required={required}
-      className={clsx(s.input, className)}
+      className={inputClassNames}
       autoComplete="off"
       autoFocus={false}
       disabled={disabled}

--- a/styles/_color.sass
+++ b/styles/_color.sass
@@ -3,3 +3,4 @@ $blue: #007DC5
 $green: #00B16B
 $black: #333132
 $gray: #CCCCCC
+$rightGray: #F5F5F5


### PR DESCRIPTION
Fixes #16

## 実装内容
- SelectBoxコンポーネント作成
- `_color.sass`にrightGray追加

## スクリーンショット

https://github.com/user-attachments/assets/9921fd76-92a7-4399-823a-94299610de96


