### PR TITLE
feat: Loaderコンポーネントの作成

### DIFF
--- a/components/atoms/Loader/Loader.module.sass
+++ b/components/atoms/Loader/Loader.module.sass
@@ -1,0 +1,8 @@
+@keyframes spin
+  0%
+    transform: rotate(0deg)
+  100%
+    transform: rotate(360deg)
+
+.loader
+  animation: spin 1s linear infinite

--- a/components/atoms/Loader/Loader.stories.ts
+++ b/components/atoms/Loader/Loader.stories.ts
@@ -1,0 +1,12 @@
+import { StoryObj } from '@storybook/react';
+import Loader from './Loader';
+
+export default {
+  component: Loader
+}
+
+type Story = StoryObj<typeof Loader>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/components/atoms/Loader/Loader.tsx
+++ b/components/atoms/Loader/Loader.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Loader as LoaderIcon } from "lucide-react";
+import clsx from "clsx";
+import s from "./Loader.module.sass";
+
+interface LoaderProps {
+  size?: number;
+  className?: string;
+}
+
+const Loader: React.FC<LoaderProps> = ({ size = 20, className }) => {
+  return (
+    <LoaderIcon
+      className={clsx(s.loader, className)}
+      size={size}
+    />
+  );
+};
+
+export default Loader;

--- a/components/molecules/Button/Button.module.sass
+++ b/components/molecules/Button/Button.module.sass
@@ -4,6 +4,9 @@
   width: 100%
   padding: 8px 16px
   +br8()
+  +flex()
+  justify-content: center
+  gap: 8px
 
   &:hover
     +opacity()

--- a/components/molecules/Button/Button.tsx
+++ b/components/molecules/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import s from "./Button.module.sass";
+import Loader from "@/components/atoms/Loader/Loader";
 
 type Props = {
   label: string;
@@ -40,7 +41,8 @@ const Button: React.FC<Props> = ({
       type={type}
       onClick={onClick}
     >
-      {isLoading ? "Loading..." : label}
+      {isLoading && <Loader />}
+      <span>{label}</span>
     </button>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "lucide-react": "^0.412.0",
         "next": "14.2.5",
         "react": "^18",
         "react-dom": "^18",
@@ -11424,6 +11425,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.412.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.412.0.tgz",
+      "integrity": "sha512-m7argY/PhSfjhwP2Dxey+VzFBvusfd8ULt+vWWFnzQhURLOtNyD1qWmMVdtJ4Nn+d+DTcoOiILrjThSjY9kaow==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "lucide-react": "^0.412.0",
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
- resolve #21 

## 実装内容
- Loaderコンポーネント作成
- **lucide-react**インストール

## スクリーンショット

https://github.com/user-attachments/assets/7d5e8900-da56-4e03-9033-3f3fc1508193

> **Buttonコンポーネントにも適用**

https://github.com/user-attachments/assets/da19c199-69ac-464e-be60-e3844a67a74c

