### PR TITLE
feat: Postコンポーネント作成

### DIFF
--- a/app/posts/style.module.sass
+++ b/app/posts/style.module.sass
@@ -1,10 +1,11 @@
 @use 'styles/index.sass' as *
 
 .container
+  position: relative
   background-color: $lightGray
   display: flex
   gap: 32px
-  min-height: 100vh
+  height: 100vh
 
   +viewM()
     gap: 16px
@@ -15,7 +16,8 @@
   .sidebar
     width: 30%
     min-width: 120px
-    overflow: hidden
+    position: sticky
+    top: 0
 
   .timeline
     flex-grow: 1

--- a/components/molecules/Button/style.module.sass
+++ b/components/molecules/Button/style.module.sass
@@ -10,7 +10,7 @@
   outline: none
 
   &:hover
-    +opacity()
+    +opacity8()
 
   +viewM()
     +fs14()

--- a/components/molecules/CustomLink/style.module.sass
+++ b/components/molecules/CustomLink/style.module.sass
@@ -5,7 +5,7 @@
   color: $black
 
   &:hover
-    +opacity()
+    +opacity8()
 
   &.blue
     color: $blue

--- a/components/molecules/ProfileIcon/ProfileIcon.tsx
+++ b/components/molecules/ProfileIcon/ProfileIcon.tsx
@@ -21,6 +21,7 @@ const ProfileIcon: React.FC<Props> = ({ src, alt, size = 60, className }) => {
         width={size}
         height={size}
         className={s.image}
+        objectFit="cover"
       />
     </div>
   );

--- a/components/organisms/SignUpForm/style.module.sass
+++ b/components/organisms/SignUpForm/style.module.sass
@@ -33,7 +33,7 @@
       border: none
 
       &:hover
-        +opacity()
+        +opacity8()
 
     .selectBoxWrapper
       display: flex

--- a/components/organisms/Timeline/Timeline.tsx
+++ b/components/organisms/Timeline/Timeline.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import s from "./style.module.sass";
 import PostBox from "./partials/PostBox/PostBox";
+import Post from "./partials/Post/Post";
 
 type Props = {
   className?: string;
@@ -11,6 +12,10 @@ const Timeline: React.FC<Props> = ({ className }) => {
     <div className={clsx(s.timeline, className)}>
       <PostBox />
       <hr className={s.hr} />
+      {Array.from({ length: 3 }).map((_, i) => (
+        <Post key={i} />
+      ))}
+      <Post />
     </div>
   );
 };

--- a/components/organisms/Timeline/partials/Post/Post.stories.ts
+++ b/components/organisms/Timeline/partials/Post/Post.stories.ts
@@ -1,0 +1,12 @@
+import { StoryObj } from '@storybook/react';
+import Post from './Post';
+
+export default {
+  component: Post
+}
+
+type Story = StoryObj<typeof Post>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/components/organisms/Timeline/partials/Post/Post.tsx
+++ b/components/organisms/Timeline/partials/Post/Post.tsx
@@ -1,0 +1,35 @@
+import { Trash2 } from "lucide-react";
+import s from "./style.module.sass";
+import ProfileIcon from "@/components/molecules/ProfileIcon/ProfileIcon";
+
+const Post: React.FC = () => {
+  return (
+    <>
+      <div className={s.postContainer}>
+        <div className={s.leftWrapper}>
+          <ProfileIcon
+            src="vercel.svg"
+            alt="vercel"
+            className={s.profileIcon}
+          />
+        </div>
+        <div className={s.rightWrapper}>
+          <p className={s.name}>Vercelさん</p>
+          <p className={s.postContent}>
+            {`Lorem ipsum dolor sit amet consectetur, adipisicing elit. Pariatur,
+            voluptatem!`}
+          </p>
+          <div className={s.bottomWrapper}>
+            <span className={s.date}>2024/07/24 02:00</span>
+            <button className={s.button}>
+              <Trash2 size={20} />
+            </button>
+          </div>
+        </div>
+      </div>
+      <hr className={s.hr} />
+    </>
+  );
+};
+
+export default Post;

--- a/components/organisms/Timeline/partials/Post/style.module.sass
+++ b/components/organisms/Timeline/partials/Post/style.module.sass
@@ -1,0 +1,56 @@
+@use 'styles/index.sass' as *
+
+.postContainer
+  padding: 24px 0
+  display: flex
+  gap: 16px
+
+  +viewM()
+    padding: 16px 0
+    gap: 8px
+
+  .leftWrapper
+    min-width: fit-content
+
+    .profileIcon
+      +viewM()
+        width: 48px!important
+        height: 48px!important
+
+      +viewS()
+        width: 40px!important
+        height: 40px!important
+
+  .rightWrapper
+    +flexCol()
+    gap: 16px
+
+    +viewM()
+      gap: 8px
+
+    .name
+      +fs18()
+      +fb()
+
+      +viewM()
+        +fs16()
+
+      +viewS()
+        +fs14()
+
+    .bottomWrapper
+      +flex()
+      justify-content: space-between
+
+      .date
+        color: $darkGray
+        +fs14()
+
+      .button
+        +flex()
+
+        &:hover
+          +opacity6()
+
+.hr
+  border: 0.5px solid $gray

--- a/components/organisms/Timeline/partials/PostBox/style.module.sass
+++ b/components/organisms/Timeline/partials/PostBox/style.module.sass
@@ -19,6 +19,10 @@
         width: 48px!important
         height: 48px!important
 
+      +viewS()
+        width: 40px!important
+        height: 40px!important
+
     .name
       +fs18()
       +fb()

--- a/components/organisms/Timeline/style.module.sass
+++ b/components/organisms/Timeline/style.module.sass
@@ -12,5 +12,8 @@
     padding: 8px 16px
 
   .hr
-    margin: 24px -40px
+    margin: 24px -40px 0
     border: 0.5px solid $gray
+
+    +viewM()
+      margin-top: 16px

--- a/styles/_mixin.sass
+++ b/styles/_mixin.sass
@@ -45,7 +45,12 @@
   flex-direction: column
   justify-content: center
 
-=opacity
+=opacity6
+  opacity: 0.6
+  transition: opacity 0.2s
+  cursor: pointer
+
+=opacity8
   opacity: 0.8
   transition: opacity 0.2s
   cursor: pointer


### PR DESCRIPTION
Fixes #51

## 実装内容
- Postコンポーネント作成
- 試しにページに適用

## スクリーンショット
> **Storybook**

<img width="751" alt="スクリーンショット 2024-07-24 10 28 10" src="https://github.com/user-attachments/assets/0b595377-3325-44ef-9aca-c7fd968db6e1">

> **/postsページ**

https://github.com/user-attachments/assets/226cdc43-d86f-4bc5-b6c3-ce399a3614f4

