### PR TITLE
feat: 新規ユーザー登録の繋ぎ込み

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env
 .env*.local
 
 # vercel

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,48 @@
+import { db, auth } from '@/config/firebase';
+import { collection, addDoc, query, where, getDocs } from 'firebase/firestore';
+import { NextResponse, NextRequest } from 'next/server';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import bcrypt from 'bcrypt';
+
+// 新規ユーザー登録
+export async function POST(request: NextRequest) {
+  const requestData = await request.json();
+  try {
+    const { username, email, password, profileIcon, dateOfBirth, gender } = requestData;
+
+    // メールアドレスが既に登録されていないか確認
+    const q = query(collection(db, 'users'), where('email', '==', email));
+    const userSnapshot = await getDocs(q);
+
+    if (!userSnapshot.empty) {
+      return NextResponse.json({ error: 'このメールアドレスは既に使用されています。' }, { status: 400 });
+    }
+
+    // パスワードをハッシュ化
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    // Firebase Authでユーザー作成
+    const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+    const user = userCredential.user;
+
+    // Firestoreにユーザーデータを保存
+    await addDoc(collection(db, 'users'), {
+      userId: user.uid,
+      username,
+      email,
+      password: hashedPassword,
+      profileIcon,
+      dateOfBirth: {
+        year: dateOfBirth.year,
+        month: dateOfBirth.month,
+        day: dateOfBirth.day,
+      },
+      gender,
+      createdAt: new Date()
+    });
+
+    return NextResponse.json({ message: '新規ユーザー登録に成功しました。' });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/components/molecules/SelectBox/SelectBox.tsx
+++ b/components/molecules/SelectBox/SelectBox.tsx
@@ -38,7 +38,6 @@ const SelectBox: React.FC<Props> = ({
     if (selected && onChange) {
       onChange(selected);
     }
-    console.log(selected);
   };
 
   const selectBoxClassNames = clsx(s.selectBox, className, {

--- a/config/firebase.ts
+++ b/config/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -14,5 +15,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
+const storage = getStorage(app)
 
-export { db, auth };
+export { db, auth, storage };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ const myRules = {
       argsIgnorePattern: "^_",
     },
   ],
+  'no-console': 'warn',
 };
 
 export default [

--- a/lib/api/auth/signUp.ts
+++ b/lib/api/auth/signUp.ts
@@ -1,0 +1,30 @@
+import { uploadProfileIcon } from "@/lib/hooks/firebase/uploadProfileIcon";
+import { SignUpSchemaClientType, signUpSchemaServer, SignUpSchemaServerType } from "@/utils/schema/signUp";
+
+export async function signUp(data: SignUpSchemaClientType) {
+  const parsedData: SignUpSchemaServerType = signUpSchemaServer.parse(data);
+
+  // プロフィール画像のアップロードとURLの取得
+  const profileIconFile = parsedData.profileIcon[0];
+  const profileIconUrl = await uploadProfileIcon(profileIconFile);
+
+  try {
+    const res = await fetch('/api/auth/signup', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({...parsedData, profileIcon: profileIconUrl}),
+    });
+
+    const result = await res.json();
+
+    if (res.ok) {
+      return { success: true, data: result };
+    } else {
+      return { success: false, error: result.error };
+    }
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/lib/hooks/firebase/uploadProfileIcon.ts
+++ b/lib/hooks/firebase/uploadProfileIcon.ts
@@ -1,0 +1,15 @@
+import { storage } from '@/config/firebase';
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+
+// File型のデータからfirebaseに画像をアップロードし、ダウンロードURLを返す
+export async function uploadProfileIcon(file: File): Promise<string> {
+  const storageRef = ref(storage, `profileIcons/${file.name}`);
+
+  // 画像をアップロード
+  await uploadBytes(storageRef, file);
+
+  // 画像のダウンロードURLを取得
+  const url = await getDownloadURL(storageRef);
+
+  return url;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -13,6 +13,23 @@ const nextConfig = {
     };
     return config;
   },
+  // 外部からの画像の読み込みを許可する
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "firebasestorage.googleapis.com",
+        port: "",
+        pathname: "/v0/b/**",
+      },
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
+    "bcrypt": "^5.1.1",
     "clsx": "^2.1.1",
     "firebase": "^10.12.4",
     "lucide-react": "^0.412.0",
@@ -34,6 +35,7 @@
     "@storybook/nextjs": "^8.2.5",
     "@storybook/react": "^8.2.5",
     "@storybook/test": "^8.2.5",
+    "@types/bcrypt": "^5.0.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
Fixes #55

## 実装内容
- APIの作成（APIを呼び出すBFF関数を別ファイルに定義し、クライアントからはその関数を呼び出す）
- API実行時、zodで型チェック
- データが保存されたらホーム画面（投稿一覧ページ）にリダイレクト

## 期待する動作
- APIがきちんと実行され、DBに保存される
- ユーザー登録が完了したら、投稿一覧ページにリダイレクトされる

## スクリーンショット
> **登録完了後、投稿一覧ページにリダイレクト**

https://github.com/user-attachments/assets/23964516-d890-40f9-8b39-65f68c168abe

> **DBに保存されてることを確認**

<img width="517" alt="スクリーンショット 2024-07-26 14 35 00" src="https://github.com/user-attachments/assets/a65b4c07-520a-4869-9524-9b91b8072b17">
