### PR TITLE
feat: ログインの繋ぎ込み

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -1,0 +1,32 @@
+import { db } from '@/config/firebase';
+import { NextResponse } from 'next/server';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import bcrypt from 'bcrypt';
+
+// ログイン
+export async function POST(request: Request) {
+  const { email, password } = await request.json();
+
+  try {
+    // ユーザー情報を取得
+    const q = query(collection(db, 'users'), where('email', '==', email));
+    const querySnapshot = await getDocs(q);
+
+    if (querySnapshot.empty) {
+      throw new Error('ユーザーが見つかりません');
+    }
+
+    const userDoc = querySnapshot.docs[0];
+    const userData = userDoc.data();
+
+    // パスワードを検証
+    const passwordMatch = await bcrypt.compare(password, userData.password);
+    if (!passwordMatch) {
+      throw new Error('パスワードが間違っています');
+    };
+
+    return NextResponse.json({ message: 'パスワードが一致しました', userId: userData.userId });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 401 });
+  }
+}

--- a/components/organisms/SignInForm/SignInForm.tsx
+++ b/components/organisms/SignInForm/SignInForm.tsx
@@ -9,6 +9,10 @@ import Title from "@/components/atoms/Title/Title";
 import { signInSchema } from "@/utils/schema/signIn";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { signIn } from "@/lib/api/auth/signIn";
+import { useRouter } from "next/navigation";
+import { signInWithEmailAndPassword } from "firebase/auth";
+import { auth } from "@/config/firebase";
 
 type SignInFormData = z.infer<typeof signInSchema>;
 
@@ -22,6 +26,7 @@ type Props = {
 };
 
 const SignInForm: React.FC<Props> = ({ className }) => {
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -32,8 +37,19 @@ const SignInForm: React.FC<Props> = ({ className }) => {
   });
 
   const handleSignIn: SubmitHandler<SignInFormData> = async (data) => {
-    await new Promise((resolve) => setTimeout(resolve, 1000)); // 1秒間の遅延
-    console.log(data);
+    const result = await signIn(data);
+    if (result.success) {
+      try {
+        await signInWithEmailAndPassword(auth, data.email, data.password);
+        router.push("/posts");
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("ログインに失敗しました:", error);
+      }
+    } else {
+      // eslint-disable-next-line no-console
+      console.error("ログイン処理中にエラーが発生しました", result.error);
+    }
   };
 
   return (

--- a/lib/api/auth/signIn.ts
+++ b/lib/api/auth/signIn.ts
@@ -1,0 +1,26 @@
+import { SingInSchemaType,  signInSchema} from "@/utils/schema/signIn";
+
+// ログイン
+export async function signIn(data: SingInSchemaType) {
+  const parsedData = signInSchema.parse(data);
+
+  try {
+    const response = await fetch('/api/auth/signin', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(parsedData),
+    });
+
+    const result = await response.json();
+
+    if (response.ok) {
+      return { success: true, data: result };
+    } else {
+      return { success: false, error: result.error };
+    }
+  } catch (error) {
+    return { success: false, error: (error as Error).message };
+  }
+}

--- a/utils/schema/signIn.ts
+++ b/utils/schema/signIn.ts
@@ -16,4 +16,4 @@ export const signInSchema = z.object({
     }),
 });
 
-export type UserSchemaType = z.infer<typeof signInSchema>;
+export type SingInSchemaType = z.infer<typeof signInSchema>;


### PR DESCRIPTION
Fixes #58

## 実装内容
- APIの作成（APIを呼び出すBFF関数を別ファイルに定義し、クライアントからはその関数を呼び出す）
- API実行時、zodで型チェック
- ログインに成功したら投稿一覧ページにリダイレクト

## 期待する動作
- ログインボタンをクリックしたら、APIの実行に成功して投稿一覧にリダイレクトされること

## スクリーンショット

https://github.com/user-attachments/assets/fcc45951-bf1c-474c-99f4-dde58fe5c61a

