### PR TITLE
feat: トップページでユーザーの認証情報を取得できた場合、投稿一覧ページにリダイレクトさせる

### DIFF
--- a/app/(auth)/page.tsx
+++ b/app/(auth)/page.tsx
@@ -1,17 +1,12 @@
-import SignUpForm from "@/components/organisms/SignUpForm/SignUpForm";
 import s from "./style.module.sass";
-import SignInForm from "@/components/organisms/SignInForm/SignInForm";
 import Header from "@/components/organisms/Header/Header";
+import Auth from "@/components/pages/Auth/Auth";
 
-export default function Auth() {
+export default function AuthPage() {
   return (
     <div className={s.mainContainer}>
       <Header />
-      <div className={s.formContainer}>
-        <SignUpForm className={s.form} />
-        <p className={s.or}>または</p>
-        <SignInForm className={s.form} />
-      </div>
+      <Auth />
     </div>
   );
 }

--- a/app/(auth)/style.module.sass
+++ b/app/(auth)/style.module.sass
@@ -10,39 +10,3 @@
 
   +viewS()
     padding: 80px 16px 16px
-
-.formContainer
-  display: flex
-  gap: 32px
-
-  +viewM()
-    +flexCol()
-    gap: 24px
-
-  +viewS()
-    gap: 16px
-
-  .form
-    flex: 1
-
-  .or
-    display: none
-
-    +viewM()
-      +flex()
-      +fs14()
-      text-align: center
-      color: $gray
-
-      &::before,
-      &::after
-        content: ""
-        height: 1px
-        flex-grow: 1
-        background-color: $gray
-
-      &::before
-        margin-right: 16px
-
-      &::after
-        margin-left: 16px

--- a/components/pages/Auth/Auth.stories.ts
+++ b/components/pages/Auth/Auth.stories.ts
@@ -1,0 +1,12 @@
+import { StoryObj } from '@storybook/react';
+import Auth from './Auth';
+
+export default {
+  component: Auth
+}
+
+type Story = StoryObj<typeof Auth>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/components/pages/Auth/Auth.tsx
+++ b/components/pages/Auth/Auth.tsx
@@ -1,0 +1,35 @@
+"use client";
+import React, { useEffect } from "react";
+import s from "./style.module.sass";
+import clsx from "clsx";
+import SignUpForm from "../../organisms/SignUpForm/SignUpForm";
+import SignInForm from "../../organisms/SignInForm/SignInForm";
+import { auth } from "@/config/firebase";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  className?: string;
+};
+
+const Auth: React.FC<Props> = ({ className }) => {
+  const router = useRouter();
+  const [user] = useAuthState(auth);
+
+  // ユーザーの認証情報がある場合は投稿一覧ページに置き換える
+  useEffect(() => {
+    if (user) {
+      router.replace("/posts");
+    }
+  }, [user, router]);
+
+  return (
+    <div className={clsx(s.container, className)}>
+      <SignUpForm className={s.form} />
+      <p className={s.or}>または</p>
+      <SignInForm className={s.form} />
+    </div>
+  );
+};
+
+export default Auth;

--- a/components/pages/Auth/style.module.sass
+++ b/components/pages/Auth/style.module.sass
@@ -1,0 +1,37 @@
+@use 'styles/index.sass' as *
+
+.container
+  display: flex
+  gap: 32px
+
+  +viewM()
+    +flexCol()
+    gap: 24px
+
+  +viewS()
+    gap: 16px
+
+  .form
+    flex: 1
+
+  .or
+    display: none
+
+    +viewM()
+      +flex()
+      +fs14()
+      text-align: center
+      color: $gray
+
+      &::before,
+      &::after
+        content: ""
+        height: 1px
+        flex-grow: 1
+        background-color: $gray
+
+      &::before
+        margin-right: 16px
+
+      &::after
+        margin-left: 16px


### PR DESCRIPTION
Fixes #65

## 実装内容
- useAuthState()で認証情報を取得したいので、新規ユーザー登録フォームとログインフォームを囲むコンポーネントを作成し、そのコンポーネントで"use client"を宣言してuseAuthState()を実行（page.tsxで"use client"は宣言しない）
- 認証情報を取得できたらrouter.push()でリダイレクト

## 期待する動作
- トップページでユーザーの認証情報を取得できた場合、投稿一覧ページにリダイレクトすること

## スクリーンショット
> **分かりづらいけど、投稿一覧ページからトップページにブラウザバックしても一瞬で戻って来る**

https://github.com/user-attachments/assets/18b1b827-d20f-41ae-801f-0200e986c3ea


