### PR TITLE
feat: zodでFileList型のデータが扱えずエラーになっている

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -8,6 +8,7 @@ import { signUpSchemaServer, SignUpSchemaServerType } from '@/utils/schema/signU
 // 新規ユーザー登録
 export async function POST(request: NextRequest) {
   const data = await request.json();
+
   try {
     const parsedData: SignUpSchemaServerType = signUpSchemaServer.parse(data)
     const { username, email, password, profileIcon, dateOfBirth, gender } = parsedData;
@@ -17,7 +18,7 @@ export async function POST(request: NextRequest) {
     const userSnapshot = await getDocs(q);
 
     if (!userSnapshot.empty) {
-      return NextResponse.json({ error: 'このメールアドレスは既に使用されています。' }, { status: 400 });
+      return NextResponse.json({ error: '登録済みのメールアドレスです' }, { status: 400 });
     }
 
     // パスワードをハッシュ化

--- a/components/organisms/SignUpForm/SignUpForm.tsx
+++ b/components/organisms/SignUpForm/SignUpForm.tsx
@@ -30,7 +30,7 @@ const defaultValues: SignUpFormSchema = {
   username: "",
   email: "",
   password: "",
-  profileIcon: "",
+  profileIcon: null,
   dateOfBirth: {
     year: 0,
     month: 0,
@@ -235,6 +235,7 @@ const SignUpForm: React.FC<Props> = ({ className }) => {
                 target="_blank"
                 underline
                 color="blue"
+                opacity
               >
                 利用規約
               </CustomLink>


### PR DESCRIPTION
Fixes #71

## 実装内容
- zodで定義したprofileIconの型（FileList）が、サーバー上で扱えなくてエラーになっているため対応
- any型として扱いつつ、バリデーションはできるように修正

## 期待する動作
- ユーザーが登録できること
